### PR TITLE
feat(product-options): Show sibling colors and refactor option rendering

### DIFF
--- a/.liquidrc
+++ b/.liquidrc
@@ -1,0 +1,48 @@
+{
+  "engine": "shopify",
+  "files": {
+    "locales": "locales/en.default.json",
+    "settings": "config/settings_schema.json",
+    "snippets": ["snippets/*.liquid"],
+    "sections": ["sections/*.liquid"]
+  },
+  "format": {
+    "ignore": [],
+    "wrap": 80,
+    "indentSize": 4,
+    "preserveLine": 2,
+    "endNewline": true,
+    "liquid": {
+      "indentAttribute": true,
+      "lineBreakSeparator": "before",
+      "normalizeSpacing": true,
+      "quoteConvert": "single",
+      "ignoreTagList": []
+    },
+    "markup": {
+      "quoteConvert": "double",
+      "selfCloseSpace": true,
+      "delimiterTerminus": "inline",
+      "stripAttributeLines": true,
+      "commentNewline": false,
+      "forceIndent": true,
+      "commentIndent": true,
+      "ignoreJS": true,
+      "ignoreCSS": false,
+      "ignoreJSON": false,
+      "forceAttribute": 3
+    },
+    "json": {
+      "bracePadding": false,
+      "braceAllman": true,
+      "arrayFormat": "indent",
+      "objectIndent": "indent",
+      "objectSort": false
+    },
+    "style": {
+      "noLeadZero": true,
+      "quoteConvert": "single",
+      "atRuleSpace": true
+    }
+  }
+}

--- a/snippets/product-block-options-color.liquid
+++ b/snippets/product-block-options-color.liquid
@@ -1,0 +1,115 @@
+{%- liquid
+  comment
+    Renders color swatches for a product block, including siblings if available.
+
+    Parameters:
+    - product {Object} - The main product object.
+    - product_option {Object} - The specific color option object (e.g., product.options_with_values[0]).
+    - sibling_products {Array} - Array of sibling product objects (from metafield).
+    - valid_sibling_count {Number} - Number of valid siblings.
+    - option_limit {Number} - Max number of swatches to show before "+ remaining" .
+    - swatch_loading {String} - 'lazy', 'eager', or 'manual' .
+    - settings {Object} - Global theme settings object.
+  endcomment
+
+  assign swatches_shown = 0
+  assign current_option_limit = option_limit | default: 3
+  assign show_sibling_swatches = false
+  if valid_sibling_count > 0
+    assign show_sibling_swatches = true
+  endif
+-%}
+
+<div class="product-block-options product-block-options--swatch" data-option-name="{{ product_option.name | escape }}">
+  <div class="product-block-options__inner">
+    {%- comment %} 1. Show current product swatch {% endcomment -%}
+    {%- liquid
+      assign current_product_item = product
+      assign swatch_label = product_option.selected_value | default: 'Default'
+
+      assign swatch_value_downcased = swatch_label | downcase
+      assign swatch_value_normalized = swatch_label | replace: '"', '' | downcase
+
+      assign current_featured_media = current_product_item.featured_media
+    -%}
+    <a
+      href="{{ current_product_item.url }}"
+      class="product-block-options__item is-active"
+      aria-label="{{ 'products.product.product_link_label' | t: title: current_product_item.title | escape }} - {{ swatch_label | escape }}"
+      data-tooltip="{{ swatch_label | escape }}"
+      data-tooltip-location="top"
+      data-swatch="{{ swatch_value_normalized }}">
+      <span class="product-block-options__item__text">{{ swatch_label | escape }}</span>
+      {%- if settings.swatch_method == 'variant-images' and current_featured_media.preview_image -%}
+        {%- render 'image'
+          , image: current_featured_media
+          , sizes: '36px'
+          , widths: '36, 72'
+          , custom_aspect_ratio: 1
+          , custom_crop: settings.swatch_crop_align
+          , loading: swatch_loading
+          , fetchpriority: 'low'
+        -%}
+      {%- endif -%}
+    </a>
+    {%- assign swatches_shown = swatches_shown | plus: 1 -%}
+
+    {%- comment %} 2. Show sibling product swatches (up to limit) {% endcomment -%}
+    {%- if show_sibling_swatches and sibling_products != blank -%}
+      {%- for sibling_product_item in sibling_products -%}
+        {%- if swatches_shown >= current_option_limit -%}
+          {%- break -%}
+        {%- endif -%}
+
+        {%- if sibling_product_item != blank and sibling_product_item.handle != product.handle -%}
+          {%- liquid
+            assign sibling_swatch_label = 'Default'
+            for option in sibling_product_item.options_with_values
+              assign sibling_option_name_downcased = option.name | downcase
+              if sibling_option_name_downcased == 'color' or sibling_option_name_downcased == 'colour'
+                assign sibling_swatch_label = option.selected_value
+                break
+              endif
+            endfor
+
+            assign sibling_swatch_value_normalized = sibling_swatch_label | replace: '"', '' | downcase
+            assign sibling_featured_media = sibling_product_item.featured_media
+          -%}
+          <a
+            href="{{ sibling_product_item.url }}"
+            class="product-block-options__item"
+            aria-label="{{ 'products.product.product_link_label' | t: title: sibling_product_item.title | escape }} - {{ sibling_swatch_label | escape }}"
+            data-tooltip="{{ sibling_swatch_label | escape }}"
+            data-tooltip-location="top"
+            data-swatch="{{ sibling_swatch_value_normalized }}">
+            <span class="product-block-options__item__text">{{ sibling_swatch_label | escape }}</span>
+            {%- if settings.swatch_method == 'variant-images' and sibling_featured_media.preview_image -%}
+              {%- render 'image'
+                , image: sibling_featured_media
+                , sizes: '36px'
+                , widths: '36, 72'
+                , custom_aspect_ratio: 1
+                , custom_crop: settings.swatch_crop_align
+                , loading: swatch_loading
+                , fetchpriority: 'low'
+              -%}
+            {%- endif -%}
+          </a>
+          {%- assign swatches_shown = swatches_shown | plus: 1 -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+
+    {%- comment %} Show "+ remaining" if needed {% endcomment -%}
+    {%- assign total_available_swatches = 1 -%}
+    {%- comment %} Start with current product {% endcomment -%}
+    {%- if show_sibling_swatches -%}
+      {%- assign total_available_swatches = total_available_swatches | plus: valid_sibling_count -%}
+    {%- endif -%}
+
+    {%- if total_available_swatches > current_option_limit -%}
+      {%- assign remaining = total_available_swatches | minus: current_option_limit -%}
+      <span class="product-block-options__more-label">+ {{ remaining }}</span>
+    {%- endif -%}
+  </div>
+</div>

--- a/snippets/product-block-options-other.liquid
+++ b/snippets/product-block-options-other.liquid
@@ -1,0 +1,164 @@
+{%- liquid
+  comment
+    Renders non-color options for a product block (text or visual swatches).
+
+    Parameters:
+    - product {Object} - The main product object.
+    - product_option {Object} - The specific option object (e.g., product.options_with_values[1]).
+    - is_text_swatch {Boolean} - True if options should be rendered as text, false for visual swatches.
+    - option_limit {Number} - Max number of swatches to show before "+ remaining" .
+    - swatch_loading {String} - 'lazy', 'eager', or 'manual' .
+    - settings {Object} - Global theme settings object.
+    - compact {Boolean} - Whether the compact view is active.
+  endcomment
+
+  assign total_available_options = 0
+  assign current_option_limit = option_limit | default: 3
+
+  assign parent_loop_index = 0
+  for po_check in product.options_with_values
+    if po_check.name == product_option.name
+      assign parent_loop_index = forloop.index0
+      break
+    endif
+  endfor
+-%}
+
+<div class="product-block-options{% unless is_text_swatch %} product-block-options--swatch{% endunless %}" data-option-name="{{ product_option.name | escape }}">
+  <div class="product-block-options__inner">
+    {%- if product.options.size == 1 and product_option.values.size == 1 -%}
+      {%- comment %} Single variant / single option case {% endcomment -%}
+      {%- for variant in product.variants -%}
+        {%- liquid
+          if compact and forloop.index > current_option_limit and is_text_swatch == false
+            break
+          endif
+          assign swatch_value = variant.options[parent_loop_index]
+          assign swatch_value_normalized = swatch_value | replace: '"', '' | downcase
+          assign variant_media = variant.featured_media
+
+          if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and variant_media == blank
+            continue
+          endif
+        -%}
+        <span
+          class="
+            product-block-options__item
+            {%- unless settings.prod_thumb_options_disable_unavailable or variant.available %} product-block-options__item--unavailable{% endunless %}
+            {% if forloop.index > current_option_limit and is_text_swatch == false %} product-block-options__item--truncated{% endif %}
+          "
+          data-option-item="{{ swatch_value | escape }}"
+          {% if variant_media %}
+          data-media="{{ variant_media.id }}"
+          {% endif %}
+          {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'swatches' -%}
+          data-swatch="{{ swatch_value_normalized }}"
+          {% endif %}
+          {%- if settings.swatch_source == 'native' and variant.options.first.swatch.color %}
+          data-swatch
+          style="--swatch-background-color: rgb({{ variant.options.first.swatch.color.rgb }})"
+          {%- endif %}>
+          <span class="product-block-options__item__text">{{ swatch_value | escape }}</span>
+          {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and variant_media.preview_image %}
+            {%- render 'image'
+              , image: variant_media
+              , sizes: '36px'
+              , widths: '36, 72'
+              , custom_aspect_ratio: 1
+              , custom_crop: settings.swatch_crop_align
+              , loading: swatch_loading
+              , fetchpriority: 'low'
+            -%}
+          {% endif %}
+        </span>
+      {%- endfor -%}
+      {%- assign total_available_options = product.variants.size -%}
+      {%- else -%}
+      {%- comment %} Multiple options/values case {% endcomment -%}
+      {%- for product_option_value in product_option.values -%}
+        {%- liquid
+          assign swatch_value_normalized = product_option_value | replace: '"', '' | downcase
+
+          if compact and forloop.index > current_option_limit and is_text_swatch == false
+            break
+          endif
+
+          assign product_option_position_index = product_option.position | minus: 1
+          assign option_value_variant = false
+          for variant_lookup in product.variants
+            if variant_lookup.options[product_option_position_index] == product_option_value
+              assign option_value_variant = variant_lookup
+              break
+            endif
+          endfor
+
+          assign is_unavailable = false
+          if settings.prod_thumb_options_disable_unavailable
+            assign is_unavailable = true
+            for variant_avail_check in product.variants
+              if variant_avail_check.available and variant_avail_check.options[product_option_position_index] == product_option_value
+                assign is_unavailable = false
+                break
+              endif
+            endfor
+          endif
+
+          assign variant_image = false
+          if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images'
+            if option_value_variant.featured_media
+              assign variant_image = option_value_variant.featured_media
+            elsif product.featured_media
+              assign variant_image = product.featured_media
+            endif
+            if variant_image == false
+              continue
+            endif
+          endif
+        -%}
+        <span
+          class="
+            product-block-options__item
+            {% if is_unavailable %} product-block-options__item--unavailable{% endif %}
+            {% if forloop.index > current_option_limit and is_text_swatch == false %} product-block-options__item--truncated{% endif %}
+          "
+          data-option-item="{{ product_option_value | escape }}"
+          {% if option_value_variant.featured_media %}
+          data-media="{{ option_value_variant.featured_media.id }}"
+          {% endif %}
+          {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'swatches' -%}
+          data-swatch="{{ swatch_value_normalized }}"
+          {% endif %}
+          {%- if settings.swatch_source == 'native' and product_option_value.swatch.color %}
+          data-swatch
+          style="--swatch-background-color: rgb({{ product_option_value.swatch.color.rgb }})"
+          {%- endif %}>
+          <span class="product-block-options__item__text">{{ product_option_value | escape }}</span>
+          {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and variant_image %}
+            {%- render 'image'
+              , image: variant_image
+              , sizes: '36px'
+              , widths: '36, 72'
+              , custom_aspect_ratio: 1
+              , custom_crop: settings.swatch_crop_align
+              , loading: swatch_loading
+              , fetchpriority: 'low'
+            -%}
+          {% endif %}
+        </span>
+      {%- endfor -%}
+      {%- assign total_available_options = product_option.values.size -%}
+    {%- endif -%}
+
+    {%- comment %} Show "+ remaining" only for truncated visual swatches {% endcomment -%}
+    {%- if total_available_options > current_option_limit and is_text_swatch == false -%}
+      {%- assign remaining = total_available_options | minus: current_option_limit -%}
+      {%- if compact -%}
+        <span class="product-block-options__more-label">+ {{ remaining }}</span>
+      {%- else -%}
+        <span class="product-block-options__more-label">
+          {{- 'products.product.more_swatches' | t: count: remaining -}}
+        </span>
+      {%- endif -%}
+    {%- endif -%}
+  </div>
+</div>

--- a/snippets/product-block.liquid
+++ b/snippets/product-block.liquid
@@ -1,20 +1,20 @@
 {%- comment -%}
-Parameters:
-  - product {Object} - Product object.
-  - no_quick_buy {Boolean} - If true, quick buy buttons are not shown (optional, default is false).
-  - no_quick_buy_markup {Boolean} - If true, quick buy button shows, but quick buy container does not (optional, default is false)
-  - custom_aspect_ratio {Number} - Aspect ratio to use for images (optional).
-  - compact {String} - Show compact version of this block (optional).
-  - card_layout {String} - May be 'landscape' or 'portrait' (optional, default is 'portrait').
-  - manual_loading {Boolean} - Whether to ensure all images need manually loading with JS (optional).
-  - prioritised_loading {Boolean} - Whether to render images immediately, not lazily (optional, default is false).
-  - icon_height {Number} - Custom icon height (optional, default is 24).
-  - grid {Number} - Desktop grid column count, used for image sizing (option, default is section.settings.grid)
+  Parameters:
+    - product {Object} - Product object.
+    - no_quick_buy {Boolean} - If true, quick buy buttons are not shown (optional, default is false).
+    - no_quick_buy_markup {Boolean} - If true, quick buy button shows, but quick buy container does not (optional, default is false)
+    - custom_aspect_ratio {Number} - Aspect ratio to use for images (optional).
+    - compact {String} - Show compact version of this block (optional).
+    - card_layout {String} - May be 'landscape' or 'portrait' (optional, default is 'portrait').
+    - manual_loading {Boolean} - Whether to ensure all images need manually loading with JS (optional).
+    - prioritised_loading {Boolean} - Whether to render images immediately, not lazily (optional, default is false).
+    - icon_height {Number} - Custom icon height (optional, default is 24).
+    - grid {Number} - Desktop grid column count, used for image sizing (option, default is section.settings.grid)
 
-  Usage:
-  {% render 'product-block',
-    product: product
-  %}
+    Usage:
+    {% render 'product-block',
+      product: product
+    %}
 {%- endcomment -%}
 {%- liquid
   if collection and settings.prod_thumb_url_within_coll and product.collections contains collection
@@ -70,8 +70,16 @@ Parameters:
   endif
 -%}
 
-<product-block class="product-block{% if compact %} product-block--compact{% endif %}{% if card_layout == 'landscape' %} product-block--landscape{% endif %}" data-product-id="{{ product.id }}">
-  <div class="block-inner"{% if animate %}{%- render 'animation-attrs', attrs: 'data-cc-animate', always: true -%}{% endif %}>
+<product-block
+  class="product-block{% if compact %} product-block--compact{% endif %}{% if card_layout == 'landscape' %} product-block--landscape{% endif %}"
+  data-product-id="{{ product.id }}"
+>
+  <div
+    class="block-inner"
+    {% if animate %}
+      {%- render 'animation-attrs', attrs: 'data-cc-animate', always: true -%}
+    {% endif %}
+  >
     <div class="block-inner-inner">
       {% if product.featured_media %}
         {%- liquid
@@ -90,12 +98,26 @@ Parameters:
           endif
         -%}
         <div class="image-cont {% if show_hover_image %}image-cont--with-secondary-image {% if aspect_ratios_same %}image-cont--same-aspect-ratio{% endif %}{% endif %}">
-          <a class="product-link{% if settings.quickbuy_style == 'whole' %}{% unless no_quick_buy %} quickbuy-toggle{% endunless %}{% endif %}" href="{{ product_url }}" aria-hidden="true" tabindex="-1">
+          <a
+            class="product-link{% if settings.quickbuy_style == 'whole' %}{% unless no_quick_buy %} quickbuy-toggle{% endunless %}{% endif %}"
+            href="{{ product_url }}"
+            aria-hidden="true"
+            tabindex="-1"
+          >
             <div class="image-label-wrap">
               <div>
                 {%- if show_hover_image -%}
-                  <div class="product-block__image product-block__image--primary{% if product.featured_media.id == product.media.first.id %}{% assign active_media_found = true %} product-block__image--active{% endif %}{% if product_images.last.id == product.featured_media.id %} product-block__image--show-on-hover{% endif %}" data-media-id="{{ product.media.first.id }}">
-                    {%- render 'image' with product.media.first.preview_image, loading: loading, size_cols_mobile: 2, size_cols_desktop: size_cols_desktop, custom_aspect_ratio: custom_aspect_ratio, custom_crop: custom_crop -%}
+                  <div
+                    class="product-block__image product-block__image--primary{% if product.featured_media.id == product.media.first.id %}{% assign active_media_found = true %} product-block__image--active{% endif %}{% if product_images.last.id == product.featured_media.id %} product-block__image--show-on-hover{% endif %}"
+                    data-media-id="{{ product.media.first.id }}"
+                  >
+                    {%- render 'image' with product.media.first.preview_image,
+                      loading: loading,
+                      size_cols_mobile: 2,
+                      size_cols_desktop: size_cols_desktop,
+                      custom_aspect_ratio: custom_aspect_ratio,
+                      custom_crop: custom_crop
+                    -%}
                   </div>
                   {%- for media in product_images offset: 1 -%}
                     {%- liquid
@@ -112,22 +134,40 @@ Parameters:
                         endif
                       endif
                     -%}
-                    <div class="product-block__image product-block__image--secondary {{ image_state_class }}"
-                        data-media-id="{{ media.id }}"
-                        data-image-index="{{ forloop.index }}">
-                      {%- render 'image' with media.preview_image, loading: hover_loading, size_cols_mobile: 2, size_cols_desktop: size_cols_desktop, custom_aspect_ratio: custom_aspect_ratio, custom_crop: custom_crop -%}
+                    <div
+                      class="product-block__image product-block__image--secondary {{ image_state_class }}"
+                      data-media-id="{{ media.id }}"
+                      data-image-index="{{ forloop.index }}"
+                    >
+                      {%- render 'image' with media.preview_image,
+                        loading: hover_loading,
+                        size_cols_mobile: 2,
+                        size_cols_desktop: size_cols_desktop,
+                        custom_aspect_ratio: custom_aspect_ratio,
+                        custom_crop: custom_crop
+                      -%}
                     </div>
                   {%- endfor -%}
                 {%- else -%}
-                  <div class="product-block__image product-block__image--primary product-block__image--active" data-media-id="{{ product.featured_media.id }}">
-                    {%- render 'image' with product.featured_media.preview_image, loading: loading, size_cols_mobile: 2, size_cols_desktop: size_cols_desktop, custom_aspect_ratio: custom_aspect_ratio, custom_crop: custom_crop -%}
+                  <div
+                    class="product-block__image product-block__image--primary product-block__image--active"
+                    data-media-id="{{ product.featured_media.id }}"
+                  >
+                    {%- render 'image' with product.featured_media.preview_image,
+                      loading: loading,
+                      size_cols_mobile: 2,
+                      size_cols_desktop: size_cols_desktop,
+                      custom_aspect_ratio: custom_aspect_ratio,
+                      custom_crop: custom_crop
+                    -%}
                   </div>
                 {%- endif -%}
               </div>
               {%- if show_hover_image -%}
                 {%- unless no_swiping -%}
                   <div class="product-block__image-dots" aria-hidden="true">
-                    <div class="product-block__image-dot product-block__image-dot--active"></div><div class="product-block__image-dot"></div>
+                    <div class="product-block__image-dot product-block__image-dot--active"></div>
+                    <div class="product-block__image-dot"></div>
                     {%- if product_images.size > 2 -%}
                       <div class="product-block__image-dot product-block__image-dot--more"></div>
                     {%- endif -%}
@@ -140,13 +180,29 @@ Parameters:
             </div>
           </a>
           {%- if show_hover_image -%}
-            <a class="image-page-button image-page-button--previous has-ltr-icon" href="#" aria-label="{{ 'general.slider.previous' | t | escape }}" tabindex="-1">{%- render 'icon-chevron-left', stroke_width: 1.3 -%}</a>
-            <a class="image-page-button image-page-button--next has-ltr-icon" href="#" aria-label="{{ 'general.slider.next' | t | escape }}" tabindex="-1">{%- render 'icon-chevron-right', stroke_width: 1.3 -%}</a>
+            <a
+              class="image-page-button image-page-button--previous has-ltr-icon"
+              href="#"
+              aria-label="{{ 'general.slider.previous' | t | escape }}"
+              tabindex="-1"
+            >
+              {%- render 'icon-chevron-left', stroke_width: 1.3 -%}
+            </a>
+            <a
+              class="image-page-button image-page-button--next has-ltr-icon"
+              href="#"
+              aria-label="{{ 'general.slider.next' | t | escape }}"
+              tabindex="-1"
+            >
+              {%- render 'icon-chevron-right', stroke_width: 1.3 -%}
+            </a>
           {%- endif -%}
 
           {%- if settings.quickbuy_style == 'button' -%}
             {%- unless no_quick_buy -%}
-              <a class="btn btn--secondary quickbuy-toggle" href="{{ product_url }}">{{ 'products.product.quick_buy' | t }}</a>
+              <a class="btn btn--secondary quickbuy-toggle" href="{{ product_url }}">
+                {{- 'products.product.quick_buy' | t -}}
+              </a>
             {%- endunless -%}
           {%- endif -%}
         </div>
@@ -156,7 +212,9 @@ Parameters:
 
           {%- if settings.quickbuy_style == 'button' -%}
             {%- unless no_quick_buy -%}
-              <a class="btn btn--secondary quickbuy-toggle" href="{{ product_url }}">{{ 'products.product.quick_buy' | t }}</a>
+              <a class="btn btn--secondary quickbuy-toggle" href="{{ product_url }}">
+                {{- 'products.product.quick_buy' | t -}}
+              </a>
             {%- endunless -%}
           {%- endif -%}
         </div>
@@ -165,7 +223,10 @@ Parameters:
       <div class="product-block__detail align-ltr-{{ settings.prod_thumb_text_align }}">
         <div class="inner">
           <div class="innerer">
-            <a class="product-link{% if settings.quickbuy_style == 'whole' %}{% unless no_quick_buy %} quickbuy-toggle{% endunless %}{% endif %}" href="{{ product_url }}">
+            <a
+              class="product-link{% if settings.quickbuy_style == 'whole' %}{% unless no_quick_buy %} quickbuy-toggle{% endunless %}{% endif %}"
+              href="{{ product_url }}"
+            >
               {%- if show_vendor -%}
                 <div class="vendor">{{ product.vendor | escape }}</div>
               {%- endif -%}
@@ -178,13 +239,33 @@ Parameters:
 
               {%- if show_price -%}
                 <div class="product-price product-price--block">
-                  {%- render 'price', product: product, show_currency_code: settings.product_currency_code_enabled, show_labels: true -%}
+                  {%- render 'price',
+                    product: product,
+                    show_currency_code: settings.product_currency_code_enabled,
+                    show_labels: true
+                  -%}
                 </div>
               {%- endif -%}
             </a>
 
             {%- if settings.swatch_source != 'none' and settings.prod_thumb_show_options and hide_swatches == blank -%}
               {%- liquid
+                assign sibling_products_from_metafield = product.metafields.custom.siblings.value | default: ""
+
+                assign valid_sibling_count = 0
+                if sibling_products_from_metafield != ""
+                  for sibling_item in sibling_products_from_metafield
+                    if sibling_item != blank and sibling_item.handle != product.handle
+                      assign valid_sibling_count = valid_sibling_count | plus: 1
+                    endif
+                  endfor
+                endif
+
+                assign show_sibling_swatches = false
+                if valid_sibling_count > 0
+                  assign show_sibling_swatches = true
+                endif
+
                 if card_layout == 'landscape'
                   assign option_limit = 5
                 else
@@ -195,191 +276,111 @@ Parameters:
                 else
                   assign swatch_loading = 'lazy'
                 endif
+                assign current_option_limit = option_limit
               -%}
-              {%- for product_option in product.options_with_values -%}
-                {%- liquid
-                  assign show_swatches = false
-                  assign is_text_swatch = false
-                  if settings.swatch_source == 'theme' and settings.swatch_option_name contains product_option.name
-                    assign show_swatches = true
-                  elsif settings.swatch_source == 'native' and settings.prod_thumb_show_options
-                    assign native_swatch_options = product_option.values | where: 'swatch'
-                    if native_swatch_options.size > 0
-                      assign show_swatches = true
-                    endif
-                  endif
-                  if show_swatches == false and settings.prod_thumb_options_names contains product_option.name
-                    assign show_swatches = true
-                    assign is_text_swatch = true
-                  endif
-                -%}
-                {%- if show_swatches -%}
-                  <div class="product-block-options{% if is_text_swatch == false %} product-block-options--swatch{% endif %}" data-option-name="{{ product_option.name | escape }}">
-                    <div class="product-block-options__inner">
-                      {%- if product.options.size == 1 -%}
-                        {%- for variant in product.variants -%}
-                          {%- liquid
-                            if compact and forloop.index > option_limit and is_text_swatch == false
-                              break
-                            endif
 
-                            if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and variant.featured_media == blank
-                              continue
-                            endif
-                          -%}
-                          <span class="product-block-options__item
-                              {%- unless settings.prod_thumb_options_disable_unavailable == false or variant.available %} product-block-options__item--unavailable{% endunless %}
-                              {%- if forloop.index > option_limit and is_text_swatch == false %} product-block-options__item--truncated{% endif %}"
-                            data-option-item="{{ variant.title | escape }}"
-                            {% if variant.featured_media %}data-media="{{ variant.featured_media.id }}"{% endif %}
-                            {% if is_text_swatch == false and settings.swatch_method == 'swatches' -%}
-                              data-swatch="{{ variant.title | replace: '"', '' | downcase }}"
-                            {%- endif %}
-                            {%- if settings.swatch_source == 'native' and variant.options.first.swatch.color %}
-                              data-swatch
-                              style="--swatch-background-color: rgb({{ variant.options.first.swatch.color.rgb }})"
-                            {%- endif %}>
-                            <span class="product-block-options__item__text">{{ variant.title | escape }}</span>
-                            {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and variant.featured_media.preview_image %}
-                              {%- render 'image',
-                                image: variant.featured_media,
-                                sizes: '36px',
-                                widths: '36, 72',
-                                custom_aspect_ratio: 1,
-                                custom_crop: settings.swatch_crop_align,
-                                loading: swatch_loading,
-                                fetchpriority: 'low'
-                              -%}
-                            {%- elsif settings.swatch_source == 'native' and variant.options.first.swatch.image -%}
-                              {%- render 'image',
-                                image: variant.options.first.swatch.image,
-                                sizes: '12px',
-                                widths: '12, 24',
-                                custom_aspect_ratio: 1,
-                                custom_crop: settings.swatch_crop_align,
-                                loading: swatch_loading,
-                                fetchpriority: 'low'
-                              -%}
-                            {% endif %}
-                          </span>
-                        {%- endfor -%}
-                        {%- if product.variants.size > option_limit and is_text_swatch == false -%}
-                          {%- assign remaining = product.variants.size | minus: option_limit -%}
-                          {%- if compact -%}
-                            <span class="product-block-options__more-label">+ {{ remaining }}</span>
-                          {%- else -%}
-                            <span class="product-block-options__more-label">{{ 'products.product.more_swatches' | t: count: remaining }}</span>
-                          {%- endif -%}
-                        {%- endif -%}
-                      {%- else -%}
-                        {%- assign product_option_position_0index = product_option.position | minus: 1 -%}
-                        {%- for product_option_value in product_option.values -%}
-                          {%- liquid
-                            if compact and forloop.index > option_limit and is_text_swatch == false
-                              break
-                            endif
+              {%- capture rendered_option_names_string %}{% endcapture -%}
+              {%- assign name_delimiter = '|||' -%}
+               {%- for product_option in product.options_with_values -%}
+                 {%- liquid
+                   assign full_option_name = product_option.name
+                   assign base_option_name = full_option_name
+ 
+                   if full_option_name contains '(' and full_option_name contains ')'
+                     assign parts_after_paren = full_option_name | split: '(' | last
+                     assign potential_base = parts_after_paren | split: ')' | first | strip
+                     if potential_base != blank
+                       assign base_option_name = potential_base
+                     endif
+                   endif
+ 
+                   assign base_option_name_downcased = base_option_name | downcase
+ 
+                   assign rendered_option_names_array = rendered_option_names_string | split: name_delimiter
+                   assign already_rendered = false
+                   for rendered_name in rendered_option_names_array
+                     if rendered_name == base_option_name_downcased
+                       assign already_rendered = true
+                       break
+                     endif
+                   endfor
+ 
+                   if already_rendered
+                     continue
+                   else
+                     capture rendered_option_names_string
+                       echo rendered_option_names_string
+                       echo base_option_name_downcased | append: name_delimiter
+                     endcapture
+                   endif
+ 
+                   assign is_color_option = false
+                   if base_option_name_downcased == 'color' or base_option_name_downcased == 'colour'
+                     assign is_color_option = true
+                   endif
+ 
+                   assign is_text_swatch = true
+                   if is_color_option and settings.swatch_source == 'theme' and settings.swatch_method != 'none'
+                     assign is_text_swatch = false
+                   elsif settings.swatch_source == 'native' and full_option_name == settings.swatch_native_option_name
+                     assign is_text_swatch = false
+                   endif
+                 -%}
 
-                            assign option_value_variant = product_option_value.variant
-                            unless option_value_variant
-                              for variant in product.variants
-                                if variant.options[product_option_position_0index] == product_option_value
-                                  assign option_value_variant = variant
-                                  break
-                                endif
-                              endfor
-                            endunless
+                 {%- comment -%} Refactor: Render options using dedicated snippets {%- endcomment -%}
+                 {%- if is_color_option -%}
+                   {%- comment -%} Always render color options if it IS a color option, let the snippet handle siblings {%- endcomment -%}
+                   {%- render 'product-block-options-color',
+                     product: product,
+                     product_option: product_option,
+                     sibling_products: sibling_products_from_metafield,
+                     valid_sibling_count: valid_sibling_count,
+                     option_limit: option_limit,
+                     swatch_loading: swatch_loading,
+                     settings: settings
+                   -%}
+                 {%- elsif is_color_option == false -%}
+                    {%- render 'product-block-options-other',
+                      product: product,
+                      product_option: product_option,
+                      is_text_swatch: is_text_swatch,
+                      option_limit: option_limit,
+                      swatch_loading: swatch_loading,
+                      settings: settings,
+                      compact: compact
+                    -%}
+                 {%- endif -%}
+               {%- endfor -%}
+             {%- endif -%}
 
-                            if settings.prod_thumb_options_disable_unavailable
-                              assign is_unavailable = true
-                              for variant in product.variants
-                                if variant.available and variant.options[product_option_position_0index] == product_option_value
-                                  assign is_unavailable = false
-                                  break
-                                endif
-                              endfor
-                            else
-                              assign is_unavailable = false
-                            endif
+             {%- if settings.enable_product_reviews_collection
+               and product.metafields.reviews.rating_count != blank
+               and compact == false
+             -%}
+               {%- assign rating_count = product.metafields.reviews.rating_count | plus: 0 -%}
+               {%- if rating_count > 0 -%}
+                 <div class="product-block__rating">
+                   {% render 'rating', rating_value: product.metafields.reviews.rating.value %}
+                   <span class="cc-rating-custom-caption">
+                     {{- 'products.product.reviews_count' | t: count: rating_count }}
+                   </span>
+                 </div>
+               {%- endif -%}
+             {%- endif -%}
+           </div>
+         </div>
+       </div>
+     </div>
+   </div>
 
-                            if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and option_value_variant.featured_media == blank
-                              continue
-                            endif
-                          -%}
-                          <span class="product-block-options__item
-                              {% if is_unavailable %} product-block-options__item--unavailable{% endif %}
-                              {% if forloop.index > option_limit and is_text_swatch == false %} product-block-options__item--truncated{% endif %}"
-                            data-option-item="{{ product_option_value | escape }}"
-                            {% if option_value_variant.featured_media %}data-media="{{ option_value_variant.featured_media.id }}"{% endif %}
-                            {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'swatches' -%}
-                              data-swatch="{{ product_option_value | replace: '"', '' | downcase }}"
-                            {% endif %}
-                            {%- if settings.swatch_source == 'native' and product_option_value.swatch.color %}
-                              data-swatch
-                              style="--swatch-background-color: rgb({{ product_option_value.swatch.color.rgb }})"
-                            {%- endif %}>
-                            <span class="product-block-options__item__text">{{ product_option_value | escape }}</span>
-                            {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and option_value_variant.featured_media.preview_image %}
-                              {%- render 'image',
-                                image: option_value_variant.featured_media,
-                                sizes: '36px',
-                                widths: '36, 72',
-                                custom_aspect_ratio: 1,
-                                custom_crop: settings.swatch_crop_align,
-                                loading: swatch_loading,
-                                fetchpriority: 'low'
-                              -%}
-                            {%- elsif settings.swatch_source == 'native' and product_option_value.swatch.image -%}
-                              {%- render 'image',
-                                image: product_option_value.swatch.image,
-                                sizes: '12px',
-                                widths: '12, 24',
-                                custom_aspect_ratio: 1,
-                                custom_crop: settings.swatch_crop_align,
-                                loading: swatch_loading,
-                                fetchpriority: 'low'
-                              -%}
-                            {% endif %}
-                          </span>
-                        {%- endfor -%}
-
-                        {%- if product_option.values.size > option_limit and is_text_swatch == false -%}
-                          {%- assign remaining = product_option.values.size | minus: option_limit -%}
-                          {%- if compact -%}
-                            <span class="product-block-options__more-label">+ {{ remaining }}</span>
-                          {%- else -%}
-                            <span class="product-block-options__more-label">{{ 'products.product.more_swatches' | t: count: remaining }}</span>
-                          {%- endif -%}
-                        {%- endif -%}
-                      {%- endif -%}
-                    </div>
-                  </div>
-                {%- endif -%}
-              {%- endfor -%}
-            {%- endif -%}
-
-            {%- if settings.enable_product_reviews_collection and product.metafields.reviews.rating_count != blank and compact == false -%}
-              {%- assign rating_count = product.metafields.reviews.rating_count | plus: 0 -%}
-              {%- if rating_count > 0 -%}
-                <div class="product-block__rating">
-                  {% render 'rating', rating_value: product.metafields.reviews.rating.value %}
-                  <span class="cc-rating-custom-caption">
-                    {{- 'products.product.reviews_count' | t: count: rating_count }}
-                  </span>
-                </div>
-              {%- endif -%}
-            {%- endif -%}
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  {%- if settings.quickbuy_style != 'off' -%}
-    {%- unless no_quick_buy_markup or no_quick_buy -%}
-      <div class="quickbuy-container use-color-scheme use-color-scheme--{{ settings.quickbuy_color_scheme }}">
-        <a href="#" class="close-detail" aria-label="{{ 'accessibility.close' | t }}" tabindex="-1">{% render 'icon-close', stroke_width: 1 %}</a>
-        <div class="inner"></div>
-      </div>
-    {%- endunless -%}
-  {%- endif -%}
-</product-block>
+   {%- if settings.quickbuy_style != 'off' -%}
+     {%- unless no_quick_buy_markup or no_quick_buy -%}
+       <div class="quickbuy-container use-color-scheme use-color-scheme--{{ settings.quickbuy_color_scheme }}">
+         <a href="#" class="close-detail" aria-label="{{ 'accessibility.close' | t }}" tabindex="-1">
+           {%- render 'icon-close', stroke_width: 1 -%}
+         </a>
+         <div class="inner"></div>
+       </div>
+     {%- endunless -%}
+   {%- endif -%}
+ </product-block>


### PR DESCRIPTION
Refactors the rendering of product options within the  snippet for improved modularity and introduces the display of sibling product colors.

- Extracts option rendering logic into two new dedicated snippets:
    - : Handles rendering of color swatches.
    - : Handles rendering of all other option types (e.g., size, material).
- Modifies  to display color swatches for sibling products (obtained from a metafield) alongside the current product's color swatch. This allows customers to see the full range of available colors for related products directly within the product block.
- Updates  to utilize these new snippets for rendering options based on their type (color vs. other).