### PR TITLE
refactor: extract swatch rendering to reusable component

### DIFF
--- a/snippets/product-block-options-color.liquid
+++ b/snippets/product-block-options-color.liquid
@@ -14,9 +14,20 @@
 
     assign swatches_shown = 0
     assign current_option_limit = option_limit | default: 3
-    assign show_sibling_swatches = false
+    
+    # Determine if we should show sibling swatches
     if valid_sibling_count > 0
         assign show_sibling_swatches = true
+    else
+        assign show_sibling_swatches = false
+    endif
+    
+    assign total_available_swatches = 1 | plus: valid_sibling_count
+    
+    # Determine swatch type based on settings
+    assign swatch_type = 'text'
+    if settings.swatch_method == 'variant-images'
+        assign swatch_type = 'image'
     endif
 -%}
 
@@ -24,84 +35,56 @@
     <div class="product-block-options__inner">
         {%- comment %} 1. Show current product swatch {% endcomment %}
         {%- liquid
-            assign current_product_item = product
             assign swatch_label = product_metafield_color | default: 'Default'
-
-            assign swatch_value_downcased = swatch_label | downcase
             assign swatch_value_normalized = swatch_label | replace: '"', '' | downcase
-
-            assign current_featured_media = current_product_item.featured_media
+            assign current_featured_media = product.featured_media
         -%}
-        <a
-            href="{{ current_product_item.url }}"
-            class="product-block-options__item is-active"
-            aria-label="{{ 'products.product.product_link_label' | t: title: current_product_item.title | escape }} - {{ swatch_label | escape }}"
-            data-tooltip="{{ swatch_label | escape }}"
-            data-tooltip-location="top"
-            data-swatch="{{ swatch_value_normalized }}">
-            <span class="product-block-options__item__text">{{ swatch_label | escape }}</span>
-            {%- if settings.swatch_method == 'variant-images' and current_featured_media.preview_image %}
-                {%- render 'image'
-                    , image: current_featured_media
-                    , sizes: '36px'
-                    , widths: '36, 72'
-                    , custom_aspect_ratio: 1
-                    , custom_crop: settings.swatch_crop_align
-                    , loading: swatch_loading
-                    , fetchpriority: 'low'
-                -%}
-            {%- endif -%}
-        </a>
-        {%- assign swatches_shown = swatches_shown | plus: 1 %}
+        
+        {%- render 'swatch-item',
+            url: product.url,
+            label: swatch_label,
+            is_active: true,
+            swatch_value: swatch_value_normalized,
+            swatch_type: swatch_type,
+            image_object: current_featured_media,
+            loading: swatch_loading,
+            settings: settings
+        -%}
+        
+        {%- assign swatches_shown = swatches_shown | plus: 1 -%}
 
         {%- comment %} 2. Show sibling product swatches (up to limit) {% endcomment %}
-        {%- if show_sibling_swatches and sibling_products != blank %}
-            {%- for sibling_product_item in sibling_products %}
-                {%- if swatches_shown >= current_option_limit %}
-                    {%- break %}
+        {%- if show_sibling_swatches and sibling_products != blank -%}
+            {%- for sibling_product_item in sibling_products -%}
+                {%- if swatches_shown >= current_option_limit -%}
+                    {%- break -%}
                 {%- endif -%}
 
-                {%- if sibling_product_item != blank and sibling_product_item.handle != product.handle %}
+                {%- if sibling_product_item != blank and sibling_product_item.handle != product.handle -%}
                     {%- liquid
                         assign sibling_swatch_label = sibling_product_item.metafields.products.colour.value | default: 'Default'
-
                         assign sibling_swatch_value_normalized = sibling_swatch_label | replace: '"', '' | downcase
                         assign sibling_featured_media = sibling_product_item.featured_media
                     -%}
-                    <a
-                        href="{{ sibling_product_item.url }}"
-                        class="product-block-options__item"
-                        aria-label="{{ 'products.product.product_link_label' | t: title: sibling_product_item.title | escape }} - {{ sibling_swatch_label | escape }}"
-                        data-tooltip="{{ sibling_swatch_label | escape }}"
-                        data-tooltip-location="top"
-                        data-swatch="{{ sibling_swatch_value_normalized }}">
-                        <span class="product-block-options__item__text">{{ sibling_swatch_label | escape }}</span>
-                        {%- if settings.swatch_method == 'variant-images' and sibling_featured_media.preview_image %}
-                            {%- render 'image'
-                                , image: sibling_featured_media
-                                , sizes: '36px'
-                                , widths: '36, 72'
-                                , custom_aspect_ratio: 1
-                                , custom_crop: settings.swatch_crop_align
-                                , loading: swatch_loading
-                                , fetchpriority: 'low'
-                            -%}
-                        {%- endif -%}
-                    </a>
-                    {%- assign swatches_shown = swatches_shown | plus: 1 %}
+                    
+                    {%- render 'swatch-item',
+                        url: sibling_product_item.url,
+                        label: sibling_swatch_label,
+                        swatch_value: sibling_swatch_value_normalized,
+                        swatch_type: swatch_type,
+                        image_object: sibling_featured_media,
+                        loading: swatch_loading,
+                        settings: settings
+                    -%}
+                    
+                    {%- assign swatches_shown = swatches_shown | plus: 1 -%}
                 {%- endif -%}
             {%- endfor -%}
         {%- endif -%}
 
         {%- comment %} Show "+ remaining" if needed {% endcomment %}
-        {%- assign total_available_swatches = 1 %}
-        {%- comment %} Start with current product {% endcomment %}
-        {%- if show_sibling_swatches %}
-            {%- assign total_available_swatches = total_available_swatches | plus: valid_sibling_count %}
-        {%- endif -%}
-
-        {%- if total_available_swatches > current_option_limit %}
-            {%- assign remaining = total_available_swatches | minus: current_option_limit %}
+        {%- if total_available_swatches > current_option_limit -%}
+            {%- assign remaining = total_available_swatches | minus: current_option_limit -%}
             <span class="product-block-options__more-label">+ {{ remaining }}</span>
         {%- endif -%}
     </div>

--- a/snippets/product-block-options-other.liquid
+++ b/snippets/product-block-options-other.liquid
@@ -1,13 +1,14 @@
 {%- liquid
   comment
     Renders non-color options for a product block (text or visual swatches).
+    Refactored to reduce duplication between single/multi option cases.
 
     Parameters:
     - product {Object} - The main product object.
     - product_option {Object} - The specific option object (e.g., product.options_with_values[1]).
     - is_text_swatch {Boolean} - True if options should be rendered as text, false for visual swatches.
-    - option_limit {Number} - Max number of swatches to show before "+ remaining" .
-    - swatch_loading {String} - 'lazy', 'eager', or 'manual' .
+    - option_limit {Number} - Max number of swatches to show before "+ remaining".
+    - swatch_loading {String} - 'lazy', 'eager', or 'manual'.
     - settings {Object} - Global theme settings object.
     - compact {Boolean} - Whether the compact view is active.
   endcomment
@@ -15,6 +16,14 @@
   assign total_available_options = 0
   assign current_option_limit = option_limit | default: 3
 
+  # Determine swatch type based on is_text_swatch
+  if is_text_swatch
+    assign swatch_type = 'text'
+  else
+    assign swatch_type = 'image'
+  endif
+
+  # Find the position index of this option
   assign parent_loop_index = 0
   for po_check in product.options_with_values
     if po_check.name == product_option.name
@@ -22,135 +31,181 @@
       break
     endif
   endfor
+
+  # Determine if we're dealing with a single variant/option case
+  assign is_single_variant_option = false
+  if product.options.size == 1 and product_option.values.size == 1
+    assign is_single_variant_option = true
+  endif
 -%}
 
 <div class="product-block-options{% unless is_text_swatch %} product-block-options--swatch{% endunless %}" data-option-name="{{ product_option.name | escape }}">
   <div class="product-block-options__inner">
-    {%- if product.options.size == 1 and product_option.values.size == 1 -%}
-      {%- comment %} Single variant / single option case {% endcomment -%}
+    {%- if is_single_variant_option -%}
+      {%- comment %} --- Single variant / single option case --- {% endcomment -%}
       {%- for variant in product.variants -%}
         {%- liquid
-          if compact and forloop.index > current_option_limit and is_text_swatch == false
-            break
-          endif
-          assign swatch_value = variant.options[parent_loop_index]
-          assign swatch_value_normalized = swatch_value | replace: '"', '' | downcase
-          assign variant_media = variant.featured_media
+          # --- Standardize variables for this item ---
+          assign item_loop_index = forloop.index
+          assign item_swatch_label = variant.options[parent_loop_index]
+          assign item_media = variant.featured_media
+          assign item_is_initially_available = variant.available
+          assign item_native_swatch_object = variant.options.first.swatch 
+          assign item_option_value_object = variant.options[parent_loop_index] 
 
-          if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and variant_media == blank
-            continue
+          # --- Common Logic Block ---
+          assign should_break_loop = false
+          if compact and item_loop_index > current_option_limit and is_text_swatch == false
+             assign should_break_loop = true
           endif
+          if should_break_loop
+             break
+          endif
+
+          assign item_swatch_value_normalized = item_swatch_label | replace: '"', '' | downcase
+
+          assign item_is_truncated = false
+          if item_loop_index > current_option_limit and is_text_swatch == false
+             assign item_is_truncated = true
+          endif
+
+          assign should_continue_due_to_image = false
+          if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and item_media == blank
+             assign should_continue_due_to_image = true
+          endif
+          if should_continue_due_to_image
+             continue
+          endif
+
+          # Availability Calculation (Single Variant Case)
+          assign item_is_unavailable = false
+          if settings.prod_thumb_options_disable_unavailable and item_is_initially_available == false
+             assign item_is_unavailable = true
+          endif
+
+          assign item_custom_style = ''
+          if settings.swatch_source == 'native' and item_native_swatch_object.color
+             assign item_custom_style = '--swatch-background-color: rgb(' | append: item_native_swatch_object.color.rgb | append: ')'
+          endif
+          # --- End Common Logic Block ---
         -%}
-        <span
-          class="
-            product-block-options__item
-            {%- unless settings.prod_thumb_options_disable_unavailable or variant.available %} product-block-options__item--unavailable{% endunless %}
-            {% if forloop.index > current_option_limit and is_text_swatch == false %} product-block-options__item--truncated{% endif %}
-          "
-          data-option-item="{{ swatch_value | escape }}"
-          {% if variant_media %}
-          data-media="{{ variant_media.id }}"
-          {% endif %}
-          {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'swatches' -%}
-          data-swatch="{{ swatch_value_normalized }}"
-          {% endif %}
-          {%- if settings.swatch_source == 'native' and variant.options.first.swatch.color %}
-          data-swatch
-          style="--swatch-background-color: rgb({{ variant.options.first.swatch.color.rgb }})"
-          {%- endif %}>
-          <span class="product-block-options__item__text">{{ swatch_value | escape }}</span>
-          {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and variant_media.preview_image %}
-            {%- render 'image'
-              , image: variant_media
-              , sizes: '36px'
-              , widths: '36, 72'
-              , custom_aspect_ratio: 1
-              , custom_crop: settings.swatch_crop_align
-              , loading: swatch_loading
-              , fetchpriority: 'low'
-            -%}
-          {% endif %}
-        </span>
+
+        {%- render 'swatch-item',
+          label: item_swatch_label,
+          is_unavailable: item_is_unavailable,
+          is_truncated: item_is_truncated,
+          swatch_value: item_swatch_value_normalized,
+          swatch_type: swatch_type,
+          image_object: item_media,
+          option_item: item_option_value_object,
+          custom_style: item_custom_style,
+          loading: swatch_loading,
+          settings: settings
+        -%}
       {%- endfor -%}
       {%- assign total_available_options = product.variants.size -%}
-      {%- else -%}
-      {%- comment %} Multiple options/values case {% endcomment -%}
+
+    {%- else -%}
+      {%- comment %} --- Multiple options/values case --- {% endcomment -%}
+      {%- liquid assign product_option_position_index = product_option.position | minus: 1 -%}
       {%- for product_option_value in product_option.values -%}
         {%- liquid
-          assign swatch_value_normalized = product_option_value | replace: '"', '' | downcase
-
-          if compact and forloop.index > current_option_limit and is_text_swatch == false
-            break
-          endif
-
-          assign product_option_position_index = product_option.position | minus: 1
+          # --- Find related variant & determine media ---
           assign option_value_variant = false
           for variant_lookup in product.variants
-            if variant_lookup.options[product_option_position_index] == product_option_value
-              assign option_value_variant = variant_lookup
-              break
-            endif
+             if variant_lookup.options[product_option_position_index] == product_option_value
+                assign option_value_variant = variant_lookup
+                break
+             endif
           endfor
 
-          assign is_unavailable = false
-          if settings.prod_thumb_options_disable_unavailable
-            assign is_unavailable = true
-            for variant_avail_check in product.variants
-              if variant_avail_check.available and variant_avail_check.options[product_option_position_index] == product_option_value
-                assign is_unavailable = false
-                break
-              endif
-            endfor
+          assign determined_media = false
+          if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images'
+             if option_value_variant and option_value_variant.featured_media
+                assign determined_media = option_value_variant.featured_media
+             elsif product.featured_media
+                assign determined_media = product.featured_media
+             endif
           endif
 
-          assign variant_image = false
-          if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images'
-            if option_value_variant.featured_media
-              assign variant_image = option_value_variant.featured_media
-            elsif product.featured_media
-              assign variant_image = product.featured_media
-            endif
-            if variant_image == false
-              continue
-            endif
+          # --- Standardize variables for this item ---
+          assign item_loop_index = forloop.index
+          assign item_swatch_label = product_option_value
+          assign item_media = determined_media 
+          assign item_is_initially_available = false
+          if option_value_variant
+             assign item_is_initially_available = option_value_variant.available
           endif
+          assign item_native_swatch_object = product_option_value.swatch
+          assign item_option_value_object = product_option_value
+
+          # --- Common Logic Block ---
+          assign should_break_loop = false
+          if compact and item_loop_index > current_option_limit and is_text_swatch == false
+             assign should_break_loop = true
+          endif
+          if should_break_loop
+             break
+          endif
+
+          assign item_swatch_value_normalized = item_swatch_label | replace: '"', '' | downcase
+
+          assign item_is_truncated = false
+          if item_loop_index > current_option_limit and is_text_swatch == false
+             assign item_is_truncated = true
+          endif
+
+          assign should_continue_due_to_image = false
+          if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and item_media == blank
+             assign should_continue_due_to_image = true
+          endif
+          if should_continue_due_to_image
+             continue
+          endif
+
+          # Availability Calculation (Multi Option Case - slightly different due to override)
+          assign item_is_unavailable = true 
+          if option_value_variant and option_value_variant.available
+             assign item_is_unavailable = false
+          endif
+          # Apply override if setting dictates ignoring availability (show all as visually available)
+          unless settings.prod_thumb_options_disable_unavailable
+             assign item_is_unavailable = false
+          endunless
+
+          assign item_custom_style = ''
+          if settings.swatch_source == 'native' and item_native_swatch_object.color
+             assign item_custom_style = '--swatch-background-color: rgb(' | append: item_native_swatch_object.color.rgb | append: ')'
+          endif
+          # --- End Common Logic Block ---
         -%}
-        <span
-          class="
-            product-block-options__item
-            {% if is_unavailable %} product-block-options__item--unavailable{% endif %}
-            {% if forloop.index > current_option_limit and is_text_swatch == false %} product-block-options__item--truncated{% endif %}
-          "
-          data-option-item="{{ product_option_value | escape }}"
-          {% if option_value_variant.featured_media %}
-          data-media="{{ option_value_variant.featured_media.id }}"
-          {% endif %}
-          {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'swatches' -%}
-          data-swatch="{{ swatch_value_normalized }}"
-          {% endif %}
-          {%- if settings.swatch_source == 'native' and product_option_value.swatch.color %}
-          data-swatch
-          style="--swatch-background-color: rgb({{ product_option_value.swatch.color.rgb }})"
-          {%- endif %}>
-          <span class="product-block-options__item__text">{{ product_option_value | escape }}</span>
-          {% if is_text_swatch == false and settings.swatch_source == 'theme' and settings.swatch_method == 'variant-images' and variant_image %}
-            {%- render 'image'
-              , image: variant_image
-              , sizes: '36px'
-              , widths: '36, 72'
-              , custom_aspect_ratio: 1
-              , custom_crop: settings.swatch_crop_align
-              , loading: swatch_loading
-              , fetchpriority: 'low'
-            -%}
-          {% endif %}
-        </span>
+
+        {%- comment %} Uses the specifically calculated value for this branch {% endcomment %}
+        {%- render 'swatch-item',
+          label: item_swatch_label,
+          is_unavailable: item_is_unavailable, 
+          is_truncated: item_is_truncated,
+          swatch_value: item_swatch_value_normalized,
+          swatch_type: swatch_type,
+          image_object: item_media,
+          option_item: item_option_value_object,
+          custom_style: item_custom_style,
+          loading: swatch_loading,
+          settings: settings
+        -%}
       {%- endfor -%}
       {%- assign total_available_options = product_option.values.size -%}
     {%- endif -%}
 
     {%- comment %} Show "+ remaining" only for truncated visual swatches {% endcomment -%}
-    {%- if total_available_options > current_option_limit and is_text_swatch == false -%}
+    {%- assign show_more_label = false -%}
+    {%- if total_available_options > current_option_limit -%}
+      {%- if is_text_swatch == false -%}
+        {%- assign show_more_label = true -%}
+      {%- endif -%}
+    {%- endif -%}
+
+    {%- if show_more_label -%}
       {%- assign remaining = total_available_options | minus: current_option_limit -%}
       {%- if compact -%}
         <span class="product-block-options__more-label">+ {{ remaining }}</span>

--- a/snippets/product-block.liquid
+++ b/snippets/product-block.liquid
@@ -17,35 +17,33 @@
     %}
 {%- endcomment -%}
 {%- liquid
+  # 1. URL and collection context
   if collection and settings.prod_thumb_url_within_coll and product.collections contains collection
     assign product_url = product.url | within: collection
   else
     assign product_url = product.url
   endif
 
+  # 2. Product images setup
   assign product_images = product.media | where: 'media_type', 'image'
   if settings.prod_thumb_hover_image and product_images.size > 1
     assign show_hover_image = true
   else
     assign show_hover_image = false
   endif
-
-  if grid == blank
-    assign size_cols_desktop = section.settings.grid
-  else
-    assign size_cols_desktop = grid
-  endif
-
-  if compact
-    assign no_swiping = true
-    assign no_quick_buy = true
-    assign show_hover_image = false
-  else
-    assign compact = false
-  endif
-
+  
+  # 3. Grid and layout settings
+  assign size_cols_desktop = grid | default: section.settings.grid
+  
+  # 4. Compact mode settings
+  assign compact = compact | default: false
+  assign no_swiping = compact
+  assign no_quick_buy = no_quick_buy | default: compact
+  
+  # 5. Variant pricing
   assign cheapest_variant = product.variants | sort: 'price' | first
-
+  
+  # 6. Image loading strategy
   if manual_loading
     assign loading = 'manual'
     assign hover_loading = 'manual'
@@ -56,7 +54,8 @@
     assign loading = 'lazy'
     assign hover_loading = 'lazy'
   endif
-
+  
+  # 7. Display settings
   if in_predictive_search
     assign show_vendor = settings.quick_search_show_vendor
     assign show_price = settings.quick_search_show_price
@@ -64,7 +63,8 @@
     assign show_vendor = section.settings.show_vendor
     assign show_price = true
   endif
-
+  
+  # 8. Aspect ratio handling
   if custom_aspect_ratio
     assign custom_aspect_ratio = custom_aspect_ratio | at_least: 0.6
   endif
@@ -83,6 +83,7 @@
     <div class="block-inner-inner">
       {% if product.featured_media %}
         {%- liquid
+          # Check if all images have the same aspect ratio
           assign aspect_ratios_same = true
           for media in product.media offset: 1
             if media.preview_image.aspect_ratio != product.media.first.preview_image.aspect_ratio
@@ -91,6 +92,7 @@
             endif
           endfor
 
+          # Determine crop settings
           if settings.prod_thumb_crop
             assign custom_crop = settings.prod_thumb_crop_align
           else
@@ -108,7 +110,11 @@
               <div>
                 {%- if show_hover_image -%}
                   <div
-                    class="product-block__image product-block__image--primary{% if product.featured_media.id == product.media.first.id %}{% assign active_media_found = true %} product-block__image--active{% endif %}{% if product_images.last.id == product.featured_media.id %} product-block__image--show-on-hover{% endif %}"
+                    class="product-block__image product-block__image--primary
+                    {%- if product.featured_media.id == product.media.first.id -%} product-block__image--active
+                    {%- endif -%}
+                    {%- if product_images.last.id == product.featured_media.id -%} product-block__image--show-on-hover
+                    {%- endif -%}"
                     data-media-id="{{ product.media.first.id }}"
                   >
                     {%- render 'image' with product.media.first.preview_image,
@@ -119,19 +125,21 @@
                       custom_crop: custom_crop
                     -%}
                   </div>
+                  {%- assign active_media_found = false -%}
+                  {%- if product.featured_media.id == product.media.first.id -%}
+                    {%- assign active_media_found = true -%}
+                  {%- endif -%}
                   {%- for media in product_images offset: 1 -%}
                     {%- liquid
-                      assign image_state_class = ''
+                      # Simplified image state class logic
                       if media.id == product.featured_media.id
-                        assign active_media_found = true
                         assign image_state_class = 'product-block__image--active'
+                        assign active_media_found = true
+                      elsif active_media_found and forloop.first
+                        assign image_state_class = 'product-block__image--show-on-hover product-block__image--inactivated'
+                        assign active_media_found = false
                       else
-                        if active_media_found
-                          assign active_media_found = false
-                          assign image_state_class = 'product-block__image--show-on-hover product-block__image--inactivated'
-                        else
-                          assign image_state_class = 'product-block__image--inactivated'
-                        endif
+                        assign image_state_class = 'product-block__image--inactivated'
                       endif
                     -%}
                     <div
@@ -250,6 +258,7 @@
 
             {%- if settings.swatch_source != 'none' and settings.prod_thumb_show_options and hide_swatches == blank -%}
               {%- liquid
+                # Pre-calculate sibling product data
                 assign sibling_products_from_metafield = product.metafields.custom.siblings.value | default: ""
                 assign product_metafield_color = product.metafields.products.colour.value | default: blank 
 
@@ -262,16 +271,13 @@
                   endfor
                 endif
 
-                assign show_sibling_swatches = false
-                if valid_sibling_count > 0
-                  assign show_sibling_swatches = true
-                endif
-
+                # Option display settings
                 if card_layout == 'landscape'
                   assign option_limit = 5
                 else
                   assign option_limit = 3
                 endif
+                
                 if manual_loading
                   assign swatch_loading = 'manual'
                 else
@@ -279,7 +285,7 @@
                 endif
               -%}
 
-              {%- comment %} NEW: Render color swatches based on metafield, outside the options loop {% endcomment %}
+              {%- comment %} Render color swatches based on metafield {% endcomment %}
               {%- if product_metafield_color != blank -%}
                 {%- render 'product-block-options-color',
                   product: product,
@@ -292,11 +298,12 @@
                 -%}
               {%- endif -%}
 
-              {%- comment %} MODIFIED: Loop for OTHER options, skipping the actual 'Color'/'Colour' option {% endcomment %}
+              {%- comment %} Loop for other options, skipping color options {% endcomment %}
               {%- capture rendered_option_names_string %}{% endcapture -%}
               {%- assign name_delimiter = '|||' -%}
               {%- for product_option in product.options_with_values -%}
                 {%- liquid
+                  # Extract base option name (handling parentheses)
                   assign full_option_name = product_option.name
                   assign base_option_name = full_option_name
 
@@ -310,15 +317,12 @@
 
                   assign base_option_name_downcased = base_option_name | downcase
 
-                  assign is_the_actual_color_option = false
+                  # Skip color options
                   if base_option_name_downcased == 'color' or base_option_name_downcased == 'colour'
-                    assign is_the_actual_color_option = true
-                  endif
-
-                  if is_the_actual_color_option
                     continue
                   endif
 
+                  # Skip already rendered options
                   assign rendered_option_names_array = rendered_option_names_string | split: name_delimiter
                   assign already_rendered = false
                   for rendered_name in rendered_option_names_array
@@ -330,20 +334,22 @@
 
                   if already_rendered
                     continue
-                  else
-                    capture rendered_option_names_string
-                      echo rendered_option_names_string
-                      echo base_option_name_downcased | append: name_delimiter
-                    endcapture
                   endif
+                  
+                  # Add to rendered options list
+                  capture rendered_option_names_string
+                    echo rendered_option_names_string
+                    echo base_option_name_downcased | append: name_delimiter
+                  endcapture
 
+                  # Determine if this is a text swatch
                   assign is_text_swatch = true
                   if settings.swatch_source == 'native' and full_option_name == settings.swatch_native_option_name
                     assign is_text_swatch = false
                   endif
                 -%}
 
-                {%- comment %} Render non-color options using the other snippet {% endcomment %}
+                {%- comment %} Render non-color options {% endcomment %}
                 {%- render 'product-block-options-other',
                   product: product,
                   product_option: product_option,

--- a/snippets/swatch-item.liquid
+++ b/snippets/swatch-item.liquid
@@ -1,0 +1,83 @@
+{%- comment -%}
+  Renders a single swatch item (link or span) for product options.
+  
+  Parameters:
+  - url {String} - URL for the swatch link (optional, if not provided renders as span)
+  - label {String} - Text label for the swatch
+  - is_active {Boolean} - Whether this swatch is the currently selected option
+  - is_unavailable {Boolean} - Whether this option is unavailable
+  - swatch_value {String} - The normalized swatch value for data attribute
+  - swatch_type {String} - Either 'color', 'image', or 'text'
+  - image_object {Object} - Media object to use for image swatches (optional)
+  - media_id {String} - ID of the media to show when this swatch is hovered (optional)
+  - custom_class {String} - Additional CSS classes to add (optional)
+  - custom_style {String} - Additional inline styles (optional)
+  - loading {String} - Image loading strategy ('lazy', 'eager', 'manual')
+  - settings {Object} - Theme settings object
+  - tooltip_location {String} - Where to position the tooltip (optional, default: 'top')
+  - is_truncated {Boolean} - Whether this swatch is visually truncated in the list (optional)
+{%- endcomment -%}
+
+{%- liquid
+  assign swatch_type = swatch_type | default: 'text'
+  assign tooltip_location = tooltip_location | default: 'top'
+  assign loading = loading | default: 'lazy'
+  
+  assign element_tag = 'span'
+  if url != blank
+    assign element_tag = 'a'
+  endif
+  
+  assign item_classes = 'product-block-options__item'
+  if is_active
+    assign item_classes = item_classes | append: ' is-active'
+  endif
+  if is_unavailable
+    assign item_classes = item_classes | append: ' product-block-options__item--unavailable'
+  endif
+  if is_truncated
+    assign item_classes = item_classes | append: ' product-block-options__item--truncated'
+  endif
+  if custom_class != blank
+    assign item_classes = item_classes | append: ' ' | append: custom_class
+  endif
+  
+  assign item_attributes = ''
+  if swatch_value != blank
+    assign item_attributes = item_attributes | append: ' data-swatch="' | append: swatch_value | append: '"'
+  endif
+  if media_id != blank
+    assign item_attributes = item_attributes | append: ' data-media="' | append: media_id | append: '"'
+  endif
+  if option_item != blank
+    assign item_attributes = item_attributes | append: ' data-option-item="' | append: option_item | escape | append: '"'
+  endif
+  if custom_style != blank
+    assign item_attributes = item_attributes | append: ' style="' | append: custom_style | append: '"'
+  endif
+-%}
+
+<{{ element_tag }}
+  class="{{ item_classes }}"
+  {%- if url != blank %} href="{{ url }}"{% endif %}
+  {%- if label != blank %} 
+    aria-label="{{ label | escape }}"
+    data-tooltip="{{ label | escape }}"
+    data-tooltip-location="{{ tooltip_location }}"
+  {%- endif %}
+  {{ item_attributes }}
+>
+  <span class="product-block-options__item__text">{{ label | escape }}</span>
+  
+  {%- if swatch_type == 'image' and image_object != blank and image_object.preview_image -%}
+    {%- render 'image'
+      , image: image_object
+      , sizes: '36px'
+      , widths: '36, 72'
+      , custom_aspect_ratio: 1
+      , custom_crop: settings.swatch_crop_align
+      , loading: loading
+      , fetchpriority: 'low'
+    -%}
+  {%- endif -%}
+</{{ element_tag }}>


### PR DESCRIPTION
- Create new swatch-item.liquid snippet for consistent swatch rendering
- Refactor product-block-options-color.liquid to use the new component
- Improve conditional logic for determining swatch visibility
- Add support for different swatch types (text/image) based on settings
- Optimize template structure for better maintainability